### PR TITLE
Honor XL_DASHBOARD order and names

### DIFF
--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -57,3 +57,27 @@ def test_show_xl_dashboard_uses_settings_order_and_names():
         'Demo keys',
         'Host keys',
     ]
+
+
+def test_show_xl_dashboard_preserves_multiple_section_order():
+    rf = RequestFactory()
+    request = rf.get('/')
+    request.user = _dummy_user()
+
+    dashboard = {
+        'General': {
+            'Users': '/users/',
+            'Social links': '/social-links/',
+        },
+        'Events': {
+            'Profiles': '/profiles/',
+            'Events': '/events/',
+        },
+    }
+
+    with override_settings(XL_DASHBOARD=dashboard):
+        result = show_xl_dashboard({'request': request}, [])
+
+    assert [sec[0] for sec in result['sections']] == ['General', 'Events']
+    assert [name for name, _ in result['sections'][0][1]] == ['Users', 'Social links']
+    assert [name for name, _ in result['sections'][1][1]] == ['Profiles', 'Events']

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,0 +1,59 @@
+import os
+import sys
+
+CURRENT_DIR = os.path.dirname(__file__)
+ROOT_DIR = os.path.dirname(CURRENT_DIR)
+PROJECT_DIR = os.path.join(CURRENT_DIR, 'project')
+sys.path.insert(0, ROOT_DIR)
+sys.path.insert(0, PROJECT_DIR)
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'project.settings')
+
+import django
+from django.test import RequestFactory, override_settings
+
+django.setup()
+
+from xldashboard.templatetags.xl_dashboard_tags import show_xl_dashboard
+
+
+def _dummy_user():
+    class DummyUser:
+        is_authenticated = True
+    return DummyUser()
+
+
+def test_show_xl_dashboard_uses_settings_order_and_names():
+    rf = RequestFactory()
+    request = rf.get('/')
+    request.user = _dummy_user()
+
+    dashboard = {
+        'Events': {
+            'Profiles': '/profiles/',
+            'Events': '/events/',
+            'Demo keys': '/demo/',
+            'Host keys': '/host/',
+        }
+    }
+
+    side_menu_list = [
+        {
+            'name': 'Wrong',
+            'models': [
+                {'name': 'Bad1', 'url': '/bad1/'},
+                {'name': 'Bad2', 'url': '/bad2/'},
+            ],
+        }
+    ]
+
+    with override_settings(XL_DASHBOARD=dashboard):
+        result = show_xl_dashboard({'request': request}, side_menu_list)
+
+    assert [sec[0] for sec in result['sections']] == ['Events']
+    assert [name for name, _ in result['sections'][0][1]] == [
+        'Profiles',
+        'Events',
+        'Demo keys',
+        'Host keys',
+    ]

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -81,3 +81,20 @@ def test_show_xl_dashboard_preserves_multiple_section_order():
     assert [sec[0] for sec in result['sections']] == ['General', 'Events']
     assert [name for name, _ in result['sections'][0][1]] == ['Users', 'Social links']
     assert [name for name, _ in result['sections'][1][1]] == ['Profiles', 'Events']
+
+
+def test_show_xl_dashboard_uses_custom_names_for_model_paths():
+    rf = RequestFactory()
+    request = rf.get('/')
+    request.user = _dummy_user()
+
+    dashboard = {
+        'General': {
+            'Account users': 'app.User',
+        }
+    }
+
+    with override_settings(XL_DASHBOARD=dashboard):
+        result = show_xl_dashboard({'request': request}, [])
+
+    assert result['sections'][0][1][0][0] == 'Account users'

--- a/xldashboard/templates/admin/base.html
+++ b/xldashboard/templates/admin/base.html
@@ -197,7 +197,6 @@
         </nav>
         {% block sidebar %}
             {% if jazzmin_settings.show_sidebar %}
-                {% get_side_menu as side_menu_list %}
                 <!-- DEBUG: Sidebar is enabled -->
                 <div id="sidebar-overlay">
                     <aside class="" id="jazzy-sidebar">
@@ -227,7 +226,7 @@
                             </div>
 
                             <nav class="mt-2 fc nav-sidebar overflow-y-auto no-scrollbar maxh-100vh">
-                                {% show_xl_dashboard side_menu_list %}
+                                {% show_xl_dashboard %}
                             </nav>
                         </div>
                     </aside>

--- a/xldashboard/templatetags/xl_dashboard_tags.py
+++ b/xldashboard/templatetags/xl_dashboard_tags.py
@@ -25,8 +25,12 @@ def show_xl_dashboard(context, side_menu_list=None):
     """
     sections: list[tuple[str, list[tuple[str, str]]]] = []
     actions = {}
+    xl_dashboard = getattr(settings, 'XL_DASHBOARD', {})
 
-    if side_menu_list is not None:
+    # Проверяем, есть ли в XL_DASHBOARD какие-либо секции кроме "xl-actions"
+    dashboard_sections_exist = any(key != 'xl-actions' for key in xl_dashboard)
+
+    if side_menu_list is not None and not dashboard_sections_exist:
         # Формируем список секций из доступных приложений и моделей
 
         # Добавляем ссылку на главную страницу админки
@@ -64,7 +68,6 @@ def show_xl_dashboard(context, side_menu_list=None):
             'request': context['request']
         }
 
-    xl_dashboard = getattr(settings, 'XL_DASHBOARD', {})
     user = context['request'].user  # noqa
 
     actions = xl_dashboard.get('xl-actions', {})

--- a/xldashboard/templatetags/xl_dashboard_tags.py
+++ b/xldashboard/templatetags/xl_dashboard_tags.py
@@ -24,13 +24,46 @@ def show_xl_dashboard(context, side_menu_list=None):
         {% show_xl_dashboard side_menu_list %}  # из списка приложений
     """
     sections: list[tuple[str, list[tuple[str, str]]]] = []
-    actions = {}
-    xl_dashboard = getattr(settings, 'XL_DASHBOARD', {})
+    xl_dashboard = getattr(settings, 'XL_DASHBOARD', {}) or {}
 
-    # Проверяем, есть ли в XL_DASHBOARD какие-либо секции кроме "xl-actions"
-    dashboard_sections_exist = any(key != 'xl-actions' for key in xl_dashboard)
+    # Разделяем экшены и секции, чтобы явно понимать, есть ли пользовательские секции
+    actions = xl_dashboard.get('xl-actions', {})
+    xl_sections = [(k, v) for k, v in xl_dashboard.items() if k != 'xl-actions']
 
-    if side_menu_list is not None and not dashboard_sections_exist:
+    if xl_sections:
+        user = context['request'].user  # noqa
+        for section_name, models_map in xl_sections:
+            items = []
+            for item_name, model_path in models_map.items():
+                if isinstance(model_path, str):
+                    if model_path.startswith('/'):
+                        # Если значение начинается с '/', считаем, что это готовая ссылка
+                        admin_link = model_path
+                        items.append((item_name, admin_link))
+                        continue
+                    try:
+                        # Пытаемся получить модель через apps.get_model
+                        try:
+                            model = apps.get_model(model_path)
+                        except LookupError:
+                            # Если не получилось – пробуем импортировать напрямую
+                            module_path, class_name = model_path.rsplit('.', 1)
+                            mod = __import__(module_path, fromlist=[class_name])
+                            model = getattr(mod, class_name)
+                        # Если модель не зарегистрирована в админке, генерировать URL не получится
+                        if model not in admin_site._registry:  # noqa
+                            raise Exception('Model not registered in admin')
+                        admin_link = reverse(
+                            f'admin:{model._meta.app_label}_{model._meta.model_name}_changelist'  # noqa
+                        )
+                        items.append((item_name, admin_link))
+                    except Exception as e:  # noqa
+                        # print(f"Ошибка для модели {model_path}: {e}")  # Лог ошибки
+                        items.append((item_name, '#invalid-model-path'))
+                else:
+                    items.append((item_name, '#unknown-type'))
+            sections.append((section_name, items))
+    elif side_menu_list is not None:
         # Формируем список секций из доступных приложений и моделей
 
         # Добавляем ссылку на главную страницу админки
@@ -61,50 +94,6 @@ def show_xl_dashboard(context, side_menu_list=None):
                     items.append((model_name, '#'))
 
             sections.append((app_name, items))
-
-        return {
-            'sections': sections,
-            'actions': actions,
-            'request': context['request']
-        }
-
-    user = context['request'].user  # noqa
-
-    actions = xl_dashboard.get('xl-actions', {})
-
-    for section_name, models_map in xl_dashboard.items():
-        if section_name == 'xl-actions':
-            continue  # пропускаем экшены, они отдельно выводятся
-        items = []
-        for item_name, model_path in models_map.items():
-            if isinstance(model_path, str):
-                if model_path.startswith('/'):
-                    # Если значение начинается с '/', считаем, что это готовая ссылка
-                    admin_link = model_path
-                    items.append((item_name, admin_link))
-                    continue
-                try:
-                    # Пытаемся получить модель через apps.get_model
-                    try:
-                        model = apps.get_model(model_path)
-                    except LookupError:
-                        # Если не получилось – пробуем импортировать напрямую
-                        module_path, class_name = model_path.rsplit('.', 1)
-                        mod = __import__(module_path, fromlist=[class_name])
-                        model = getattr(mod, class_name)
-                    # Если модель не зарегистрирована в админке, генерировать URL не получится
-                    if model not in admin_site._registry:  # noqa
-                        raise Exception('Model not registered in admin')
-                    admin_link = reverse(
-                        f'admin:{model._meta.app_label}_{model._meta.model_name}_changelist'  # noqa
-                    )
-                    items.append((item_name, admin_link))
-                except Exception as e:  # noqa
-                    # print(f"Ошибка для модели {model_path}: {e}")  # Лог ошибки
-                    items.append((item_name, '#invalid-model-path'))
-            else:
-                items.append((item_name, '#unknown-type'))
-        sections.append((section_name, items))
 
     return {
         'sections': sections,


### PR DESCRIPTION
## Summary
- Ensure `show_xl_dashboard` prefers `XL_DASHBOARD` config over Jazzmin side menu, preserving custom order and labels
- Add regression test to verify configured section order and names are honored

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa63efb8108330919b75fd21d855ef